### PR TITLE
Update pylama.cfg

### DIFF
--- a/config/pylama.cfg
+++ b/config/pylama.cfg
@@ -13,7 +13,7 @@ linters = pylint,pyflakes,radon
 # Conventions and Refactor recommendations are disabled for the CI system, but should be turned on when developing code
 # C0301 is line length, as long as you use black to format your code it will be perfect
 # W0612 is for unused variables, pyflakes reports if a variable is assigned to and still unused which is more useful
-disable = C0301,W0612
+disable = C0301,W0612,E0401
 # resolves import error for lxml packages
 extension-pkg-whitelist=lxml
 


### PR DESCRIPTION
Pylint throws error like "E0401 Unable to import 'board' [pylint]" for every module not available in Python, we should disable this error.