### PR TITLE
Setup EPS development

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,67 +1,16 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
+# RAPID-0 Policy: Each application is owned by the subteam lead of
+# the team in charge of that application and up to one other person
+# designated by the former. All software not included in a specific
+# application is owned by the PM, CE, and any subteam leads who are
+# considered qualified to manage software project-wide by the former.
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-*       @anniexiang01 @Randall-Scharpf
+* @Touwfoo @Randall-Scharpf @anniexiang01
 
-# Order is important; the last matching pattern takes the most
-# precedence. When someone opens a pull request that only
-# modifies JS files, only @js-owner and not the global
-# owner(s) will be requested for a review.
-# *.js    @js-owner #This is an inline comment.
+/applications/*adcs*/ @sethferrell
+/applications/*cdh*/ @anniexiang01
+/applications/*eps*/ @Randall-Scharpf
 
-# You can also use email addresses if you prefer. They'll be
-# used to look up users just like we do for commit author
-# emails.
-# *.go docs@example.com
-
-# Teams can be specified as code owners as well. Teams should
-# be identified in the format @org/team-name. Teams must have
-# explicit write access to the repository. In this example,
-# the octocats team in the octo-org organization owns all .txt files.
-# *.txt @octo-org/octocats
-
-# In this example, @doctocat owns any files in the build/logs
-# directory at the root of the repository and any of its
-# subdirectories.
-# /build/logs/ @doctocat
-
-# The `docs/*` pattern will match files like
-# `docs/getting-started.md` but not further nested files like
-# `docs/build-app/troubleshooting.md`.
-# docs/*  docs@example.com
-
-# In this example, @octocat owns any file in an apps directory
-# anywhere in your repository.
-# apps/ @octocat
-
-# In this example, @doctocat owns any file in the `/docs`
-# directory in the root of your repository and any of its
-# subdirectories.
-# /docs/ @doctocat
-
-# In this example, any change inside the `/scripts` directory
-# will require approval from @doctocat or @octocat.
-# /scripts/ @doctocat @octocat
-
-# In this example, @octocat owns any file in a `/logs` directory such as
-# `/build/logs`, `/scripts/logs`, and `/deeply/nested/logs`. Any changes
-# in a `/logs` directory will require approval from @octocat.
-# **/logs @octocat
-
-# In this example, @octocat owns any file in the `/apps`
-# directory in the root of your repository except for the `/apps/github`
-# subdirectory, as its owners are left empty. Without an owner, changes
-# to `apps/github` can be made with the approval of any user who has
-# write access to the repository.
-# /apps/ @octocat
-# /apps/github
-
-# In this example, @octocat owns any file in the `/apps`
-# directory in the root of your repository except for the `/apps/github`
-# subdirectory, as this subdirectory has its own owner @doctocat
-# /apps/ @octocat
-# /apps/github @doctocat
+# Any subteam-specific application which does NOT contain the name
+# of the subsystem owning the application should be specially cleared
+# by someone who is also an owner of software not specific to any
+# application, and then be listed below.

--- a/applications/eps_flatsat/code.py
+++ b/applications/eps_flatsat/code.py
@@ -1,0 +1,39 @@
+import microcontroller
+import digitalio
+import busio
+
+import asyncio
+import time
+
+
+async def battey_management_task():
+    while True:
+        await asyncio.sleep(0)
+
+
+async def output_bus_control_task():
+    while True:
+        await asyncio.sleep(0)
+
+
+async def data_recording_task():
+    while True:
+        await asyncio.sleep(0)
+
+
+async def intersubsystem_communication_task():
+    while True:
+        await asyncio.sleep(0)
+
+
+async def gathered_task():
+    await asyncio.gather(
+        battey_management_task(),
+        output_bus_control_task(),
+        data_recording_task(),
+        intersubsystem_communication_task(),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(gathered_task())

--- a/applications/eps_flatsat/pinout.py
+++ b/applications/eps_flatsat/pinout.py
@@ -1,0 +1,34 @@
+import microcontroller
+
+# power supply control pins
+EN_3V3_BUS = microcontroller.pin.PA12
+EN_5V_BUS = microcontroller.pin.PA13
+EN_12VLP_BUS = microcontroller.pin.PA14
+EN_12VHP_BUS = microcontroller.pin.PA15
+
+# SPI to ADS1118 ADCs on the board and the solar array
+ADC_SCK = microcontroller.pin.PA17
+ADC_MOSI = microcontroller.pin.PA16
+ADC_MISO = microcontroller.pin.PA19
+ADC_CS1 = microcontroller.pin.PA18
+ADC_CS2 = microcontroller.pin.PA23
+ADC_CS3 = microcontroller.pin.PA22
+ADC_CS4 = microcontroller.pin.PB23
+ADC_CS5 = microcontroller.pin.PB22
+ADC_CS6 = microcontroller.pin.PA27
+ADC_XCS1 = microcontroller.pin.PA00
+ADC_XCS2 = microcontroller.pin.PA01
+ADC_XCS3 = microcontroller.pin.PA02
+ADC_XCS4 = microcontroller.pin.PB04
+
+# battery pack balancing controls
+pass
+
+# battery pack protection controls
+pass
+
+# inter-subsystem SPI bus
+BUS_SCK = microcontroller.pin.PB17
+BUS_MOSI = microcontroller.pin.PA21
+BUS_MISO = microcontroller.pin.PB16
+EPS_CS = microcontroller.pin.PA20

--- a/tools/deploy_to_usb.py
+++ b/tools/deploy_to_usb.py
@@ -14,6 +14,10 @@ def GREEN(text):
     return "\033[92m" + text + "\033[0m"
 
 
+def YELLOW(text):
+    return "\033[93m" + text + "\033[0m"
+
+
 def CYAN(text):
     return "\033[96m" + text + "\033[0m"
 
@@ -92,7 +96,7 @@ parser = argparse.ArgumentParser(
     + "general lib folders with board-specific lib folders. The program must be run "
     + "from the root directory of a properly-structured spacecraft software project."
 )
-parser.add_argument("deploy_type", nargs="?", default="flight_computer")
+parser.add_argument("deploy_type")
 parser.add_argument("target_drive", nargs="?", default="CIRCUITPY")
 args = parser.parse_args()
 print(
@@ -101,10 +105,19 @@ print(
     )
 )
 
-if args.deploy_type not in os.listdir(os.path.join(".", "applications")):
+deploy_types = os.listdir(os.path.join(".", "applications"))
+if args.deploy_type not in deploy_types:
     print(
         RED(f"ERROR: No software found for target {args.deploy_type}"), file=sys.stderr
     )
+    deploy_types_string = filter(
+        (lambda x: (len(x) < 8) or (x[-8:] != "_testapp")), deploy_types
+    )
+    deploy_types_string = list(map((lambda x: YELLOW(x)), deploy_types_string))
+    deploy_types_string = (
+        ", ".join(deploy_types_string[:-1]) + ", and " + deploy_types_string[-1]
+    )
+    print(f"Available deploy types are {deploy_types_string}", file=sys.stderr)
     exit()
 
 target_drives = [
@@ -122,7 +135,7 @@ if len(target_drives) != 1:
     )
     print(
         RED(
-            "ERROR: Exited without deploying the CDH FC software. "
+            "ERROR: Exited without deploying the software. "
             + "Rename a drive, or target a drive name that is unique and exists."
         ),
         file=sys.stderr,


### PR DESCRIPTION
- Modify the `deploy_to_usb` script to require a deploy type parameter, since we're now using the script with many boards at the same time and it would be risky to default to deploying any particular code onto every subteam's board
- Modify CODEOWNERS to give each subteam lead control over specific applications for their own boards and define software ownership policies
- Add an `eps_flatsat` application for the EPS team to use in its current development